### PR TITLE
Next minor version improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub struct TypedEmitter<Key, CallBackParameter, CallBackReturnType = ()> {
     pub all_listener: Arc<RwLock<Option<TypedListener<CallBackParameter, CallBackReturnType>>>>,
 }
 
-impl<K: Eq + Hash + Clone, P: Clone, R> Default for TypedEmitter<K, P, R> {
+impl<K: Eq + Hash, P, R> Default for TypedEmitter<K, P, R> {
     fn default() -> Self {
         Self {
             listeners: Default::default(),
@@ -166,7 +166,7 @@ impl<K: Eq + Hash + Clone, P: Clone, R> Default for TypedEmitter<K, P, R> {
     }
 }
 
-impl<K: Eq + Hash + Clone, P: Clone, R: Clone> TypedEmitter<K, P, R> {
+impl<K: Eq + Hash, P: Clone, R> TypedEmitter<K, P, R> {
     pub fn new() -> Self {
         Self::default()
     }
@@ -253,7 +253,7 @@ impl<K: Eq + Hash + Clone, P: Clone, R: Clone> TypedEmitter<K, P, R> {
                 return Some(id_to_delete.to_string());
             }
         }
-        let all_listener = self.all_listener.read().unwrap().clone();
+        let all_listener = self.all_listener.read().unwrap();
         // check if the id matches that of the global listener;
         if let Some(all_listener) = all_listener.as_ref() {
             if id_to_delete == all_listener.id {
@@ -320,7 +320,7 @@ impl<K: Eq + Hash + Clone, P: Clone, R: Clone> TypedEmitter<K, P, R> {
             callback: Arc::new(parsed_callback),
         };
 
-        self.all_listener.write().unwrap().replace(listener.clone());
+        self.all_listener.write().unwrap().replace(listener);
 
         id
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,7 @@ pub struct TypedEmitter<Key, CallBackParameter, CallBackReturnType = ()> {
     pub all_listener: Arc<RwLock<Option<TypedListener<CallBackParameter, CallBackReturnType>>>>,
 }
 
-impl<K: Eq + Hash + Clone, P: Clone + Send + Sync + 'static, R: Send + 'static + Clone> Default
-    for TypedEmitter<K, P, R>
-{
+impl<K: Eq + Hash + Clone, P: Clone, R> Default for TypedEmitter<K, P, R> {
     fn default() -> Self {
         Self {
             listeners: Default::default(),
@@ -168,9 +166,7 @@ impl<K: Eq + Hash + Clone, P: Clone + Send + Sync + 'static, R: Send + 'static +
     }
 }
 
-impl<K: Eq + Hash + Clone, P: Clone + Send + Sync + 'static, R: Send + 'static + Clone>
-    TypedEmitter<K, P, R>
-{
+impl<K: Eq + Hash + Clone, P: Clone, R: Clone> TypedEmitter<K, P, R> {
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl<T, P> PartialEq for TypedListener<T, P> {
 use dashmap::DashMap;
 type ListenerMap<K, T, R> = Arc<DashMap<K, Vec<TypedListener<T, R>>>>;
 #[derive(Clone)]
-pub struct TypedEmitter<Key, CallBackParameter, CallBackReturnType> {
+pub struct TypedEmitter<Key, CallBackParameter, CallBackReturnType = ()> {
     pub listeners: ListenerMap<Key, CallBackParameter, CallBackReturnType>,
     pub all_listener: Arc<RwLock<Option<TypedListener<CallBackParameter, CallBackReturnType>>>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub struct TypedEmitter<Key, CallBackParameter, CallBackReturnType = ()> {
     pub all_listener: Arc<RwLock<Option<TypedListener<CallBackParameter, CallBackReturnType>>>>,
 }
 
-impl<K: Eq + Hash, P, R> Default for TypedEmitter<K, P, R> {
+impl<K: Eq + Hash + Clone, P: Clone, R> Default for TypedEmitter<K, P, R> {
     fn default() -> Self {
         Self {
             listeners: Default::default(),
@@ -166,7 +166,7 @@ impl<K: Eq + Hash, P, R> Default for TypedEmitter<K, P, R> {
     }
 }
 
-impl<K: Eq + Hash, P: Clone, R> TypedEmitter<K, P, R> {
+impl<K: Eq + Hash + Clone, P: Clone, R: Clone> TypedEmitter<K, P, R> {
     pub fn new() -> Self {
         Self::default()
     }
@@ -253,7 +253,7 @@ impl<K: Eq + Hash, P: Clone, R> TypedEmitter<K, P, R> {
                 return Some(id_to_delete.to_string());
             }
         }
-        let all_listener = self.all_listener.read().unwrap();
+        let all_listener = self.all_listener.read().unwrap().clone();
         // check if the id matches that of the global listener;
         if let Some(all_listener) = all_listener.as_ref() {
             if id_to_delete == all_listener.id {
@@ -320,7 +320,7 @@ impl<K: Eq + Hash, P: Clone, R> TypedEmitter<K, P, R> {
             callback: Arc::new(parsed_callback),
         };
 
-        self.all_listener.write().unwrap().replace(listener);
+        self.all_listener.write().unwrap().replace(listener.clone());
 
         id
     }

--- a/tests/emitter-async-std.rs
+++ b/tests/emitter-async-std.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused)]
 mod tester {
     pub use async_std::test;
 }
@@ -7,6 +8,7 @@ mod typed_async_emitter_async_std {
     use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use typed_emitter::TypedEmitter;
+    use uuid::Uuid;
 
     #[tester::test]
     async fn test_async_event_emitter_new() {
@@ -20,10 +22,9 @@ mod typed_async_emitter_async_std {
         let event = "test_event".to_string();
 
         let id = emitter.on(event.clone(), |value| async move {
-            format!("Received: {}", value)
+            format!("Received: {value}")
         });
 
-        assert!(!id.is_empty());
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
     }
@@ -34,10 +35,9 @@ mod typed_async_emitter_async_std {
         let event = "test_event".to_string();
 
         let id = emitter.once(event.clone(), |value| async move {
-            format!("Received once: {}", value)
+            format!("Received once: {value}")
         });
 
-        assert!(!id.is_empty());
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap()[0].limit, Some(1));
@@ -57,7 +57,7 @@ mod typed_async_emitter_async_std {
             let result = Arc::clone(&result_clone);
             async move {
                 let mut result = result.lock().await;
-                result.push(format!("Received: {}", value));
+                result.push(format!("Received: {value}"));
                 "OK".to_string()
             }
         });
@@ -79,12 +79,12 @@ mod typed_async_emitter_async_std {
 
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
 
-        let removed_id = emitter.remove_listener(&id);
+        let removed_id = emitter.remove_listener(id);
         assert_eq!(removed_id, Some(id));
         assert!(emitter.listeners.get(&event).unwrap().is_empty());
 
-        let non_existent_id = "non_existent_id".to_string();
-        let removed_id = emitter.remove_listener(&non_existent_id);
+        let non_existent_id = Uuid::new_v4();
+        let removed_id = emitter.remove_listener(non_existent_id);
         assert_eq!(removed_id, None);
     }
 
@@ -103,7 +103,7 @@ mod typed_async_emitter_async_std {
         instance.emit("test_event", count_clone).await;
         assert!(instance.all_listener.read().unwrap().is_some());
         assert_eq!(emit_count.load(std::sync::atomic::Ordering::SeqCst), 2);
-        instance.remove_listener(&id);
+        instance.remove_listener(id);
         assert!(instance.all_listener.read().unwrap().is_none());
     }
 }

--- a/tests/emitter-async-std.rs
+++ b/tests/emitter-async-std.rs
@@ -13,7 +13,7 @@ mod typed_async_emitter_async_std {
     #[tester::test]
     async fn test_async_event_emitter_new() {
         let emitter: TypedEmitter<String, i32, ()> = TypedEmitter::new();
-        assert!(emitter.listeners.is_empty());
+        assert_eq!(emitter.event_count(), 0);
     }
 
     #[tester::test]
@@ -25,8 +25,7 @@ mod typed_async_emitter_async_std {
             format!("Received: {value}")
         });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
     }
 
     #[tester::test]
@@ -38,9 +37,8 @@ mod typed_async_emitter_async_std {
             format!("Received once: {value}")
         });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap()[0].limit, Some(1));
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
+        assert_eq!(emitter.listeners_by_event(&event)[0].limit, Some(1));
     }
 
     #[tester::test]
@@ -77,11 +75,11 @@ mod typed_async_emitter_async_std {
 
         let id = emitter.on(event.clone(), |_| async { "OK".to_string() });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
 
         let removed_id = emitter.remove_listener(id);
         assert_eq!(removed_id, Some(id));
-        assert!(emitter.listeners.get(&event).unwrap().is_empty());
+        assert!(emitter.listeners_by_event(&event).is_empty());
 
         let non_existent_id = Uuid::new_v4();
         let removed_id = emitter.remove_listener(non_existent_id);
@@ -101,9 +99,7 @@ mod typed_async_emitter_async_std {
         let id = instance.on_all(callback);
         instance.on("test_event", callback);
         instance.emit("test_event", count_clone).await;
-        assert!(instance.all_listener.read().unwrap().is_some());
         assert_eq!(emit_count.load(std::sync::atomic::Ordering::SeqCst), 2);
         instance.remove_listener(id);
-        assert!(instance.all_listener.read().unwrap().is_none());
     }
 }

--- a/tests/emitter-smol.rs
+++ b/tests/emitter-smol.rs
@@ -12,7 +12,7 @@ mod typed_async_emitter_smol {
     #[apply(test)]
     async fn test_async_event_emitter_new() {
         let emitter: TypedEmitter<String, i32, ()> = TypedEmitter::new();
-        assert!(emitter.listeners.is_empty());
+        assert_eq!(emitter.event_count(), 0);
     }
 
     #[apply(test)]
@@ -24,8 +24,8 @@ mod typed_async_emitter_smol {
             format!("Received: {value}")
         });
 
-        assert_eq!(emitter.listeners.len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.event_count(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
     }
 
     #[apply(test)]
@@ -37,9 +37,9 @@ mod typed_async_emitter_smol {
             format!("Received once: {value}")
         });
 
-        assert_eq!(emitter.listeners.len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap()[0].limit, Some(1));
+        assert_eq!(emitter.event_count(), 1);
+        assert_eq!(emitter.listeners_by_event(&event).len(), 1);
+        assert_eq!(emitter.listeners_by_event(&event)[0].limit, Some(1));
     }
 
     #[apply(test)]
@@ -76,11 +76,11 @@ mod typed_async_emitter_smol {
 
         let id = emitter.on(event.clone(), |_| async { "OK".to_string() });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
 
         let removed_id = emitter.remove_listener(id);
         assert_eq!(removed_id, Some(id));
-        assert!(emitter.listeners.get(&event).unwrap().is_empty());
+        assert!(emitter.listeners_by_event(&event).is_empty());
 
         let non_existent_id = Uuid::new_v4();
         let removed_id = emitter.remove_listener(non_existent_id);
@@ -97,12 +97,9 @@ mod typed_async_emitter_smol {
             value.clone()
         };
 
-        let id = instance.on_all(callback);
+        let _id = instance.on_all(callback);
         instance.on("test_event", callback);
         instance.emit("test_event", count_clone).await;
-        assert!(instance.all_listener.read().unwrap().is_some());
         assert_eq!(emit_count.load(std::sync::atomic::Ordering::SeqCst), 2);
-        instance.remove_listener(id);
-        assert!(instance.all_listener.read().unwrap().is_none());
     }
 }

--- a/tests/emitter-tokio.rs
+++ b/tests/emitter-tokio.rs
@@ -13,7 +13,7 @@ mod typed_async_emitter_tokio {
     #[tester::test]
     async fn test_async_event_emitter_new() {
         let emitter: TypedEmitter<String, i32, ()> = TypedEmitter::new();
-        assert!(emitter.listeners.is_empty());
+        assert_eq!(emitter.event_count(), 0);
     }
 
     #[tester::test]
@@ -25,8 +25,7 @@ mod typed_async_emitter_tokio {
             format!("Received: {value}")
         });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
     }
 
     #[tester::test]
@@ -38,9 +37,8 @@ mod typed_async_emitter_tokio {
             format!("Received once: {value}")
         });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
-        assert_eq!(emitter.listeners.get(&event).unwrap()[0].limit, Some(1));
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
+        assert_eq!(emitter.listeners_by_event(&event)[0].limit, Some(1));
     }
 
     #[tester::test]
@@ -77,11 +75,11 @@ mod typed_async_emitter_tokio {
 
         let id = emitter.on(event.clone(), |_| async { "OK".to_string() });
 
-        assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
+        assert_eq!(emitter.listener_count_by_event(&event), 1);
 
         let removed_id = emitter.remove_listener(id);
         assert_eq!(removed_id, Some(id));
-        assert!(emitter.listeners.get(&event).unwrap().is_empty());
+        assert!(emitter.listeners_by_event(&event).is_empty());
 
         let non_existent_id = Uuid::new_v4();
         let removed_id = emitter.remove_listener(non_existent_id);
@@ -101,9 +99,6 @@ mod typed_async_emitter_tokio {
         let id = instance.on_all(callback);
         instance.on("test_event", callback);
         instance.emit("test_event", count_clone).await;
-        assert!(instance.all_listener.read().unwrap().is_some());
         assert_eq!(emit_count.load(std::sync::atomic::Ordering::SeqCst), 2);
-        instance.remove_listener(id);
-        assert!(instance.all_listener.read().unwrap().is_none());
     }
 }

--- a/tests/emitter-tokio.rs
+++ b/tests/emitter-tokio.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused)]
 mod tester {
     pub use tokio::test;
 }
@@ -7,6 +8,7 @@ mod typed_async_emitter_tokio {
     use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use typed_emitter::TypedEmitter;
+    use uuid::Uuid;
 
     #[tester::test]
     async fn test_async_event_emitter_new() {
@@ -20,10 +22,9 @@ mod typed_async_emitter_tokio {
         let event = "test_event".to_string();
 
         let id = emitter.on(event.clone(), |value| async move {
-            format!("Received: {}", value)
+            format!("Received: {value}")
         });
 
-        assert!(!id.is_empty());
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
     }
@@ -34,10 +35,9 @@ mod typed_async_emitter_tokio {
         let event = "test_event".to_string();
 
         let id = emitter.once(event.clone(), |value| async move {
-            format!("Received once: {}", value)
+            format!("Received once: {value}")
         });
 
-        assert!(!id.is_empty());
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
         assert_eq!(emitter.listeners.get(&event).unwrap()[0].limit, Some(1));
@@ -57,7 +57,7 @@ mod typed_async_emitter_tokio {
             let result = Arc::clone(&result_clone);
             async move {
                 let mut result = result.lock().await;
-                result.push(format!("Received: {}", value));
+                result.push(format!("Received: {value}"));
                 "OK".to_string()
             }
         });
@@ -79,12 +79,12 @@ mod typed_async_emitter_tokio {
 
         assert_eq!(emitter.listeners.get(&event).unwrap().len(), 1);
 
-        let removed_id = emitter.remove_listener(&id);
+        let removed_id = emitter.remove_listener(id);
         assert_eq!(removed_id, Some(id));
         assert!(emitter.listeners.get(&event).unwrap().is_empty());
 
-        let non_existent_id = "non_existent_id".to_string();
-        let removed_id = emitter.remove_listener(&non_existent_id);
+        let non_existent_id = Uuid::new_v4();
+        let removed_id = emitter.remove_listener(non_existent_id);
         assert_eq!(removed_id, None);
     }
 
@@ -103,7 +103,7 @@ mod typed_async_emitter_tokio {
         instance.emit("test_event", count_clone).await;
         assert!(instance.all_listener.read().unwrap().is_some());
         assert_eq!(emit_count.load(std::sync::atomic::Ordering::SeqCst), 2);
-        instance.remove_listener(&id);
+        instance.remove_listener(id);
         assert!(instance.all_listener.read().unwrap().is_none());
     }
 }


### PR DESCRIPTION
### Improvements
- Default return is tuple if none is passed
-  Remove unnecessary extra traits bound on the key, Parameter and return type (only Clone is needed for the key and value)
-  Use UUIDs directly as Listener IDs instead of Strings.
- Use futures::Ordered to emit events with the order of listener creation in consideration 